### PR TITLE
Better uniqueness test

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -66,7 +66,9 @@ _LATEST_MANIFEST_TAGS = MappingProxyType(
 _LATEST_DATAMODELS_URI = next(uri for uri in _LATEST_MANIFEST_URIS if "static" not in uri)
 _LATEST_STATIC_URI = next(uri for uri in _LATEST_MANIFEST_URIS if "static" in uri)
 _LATEST_DATAMODEL_URIS = tuple(uri["schema_uri"] for uri in _LATEST_MANIFEST_URIS[_LATEST_DATAMODELS_URI]["tags"])
-_LATEST_ARCHIVE_URIS = tuple(schema["id"] for schema in _LATEST_PATHS.values() if "archive_meta" in schema)
+_LATEST_ARCHIVE_URIS = MappingProxyType(
+    {schema["id"]: schema["archive_meta"] for schema in _LATEST_PATHS.values() if "archive_meta" in schema}
+)
 
 
 _PREVIOUS_DATAMODELS_URI = _find_latest(
@@ -142,12 +144,35 @@ def latest_uri(latest_schema):
     return latest_schema["id"]
 
 
+@pytest.fixture(scope="session")
+def latest_archive_metas():
+    """
+    Get the archive_meta -> uri mapping
+    """
+    archive_metas = {}
+    for uri, meta in _LATEST_ARCHIVE_URIS.items():
+        if meta not in archive_metas:
+            archive_metas[meta] = set()
+
+        archive_metas[meta].add(uri)
+
+    return archive_metas
+
+
 @pytest.fixture(scope="session", params=_LATEST_ARCHIVE_URIS)
 def latest_archive_uri(request):
     """
     Get a latest archive resource URI
     """
     return request.param
+
+
+@pytest.fixture(scope="session")
+def latest_archive_meta(latest_archive_uri):
+    """
+    Get the latest archive metadata
+    """
+    return _LATEST_ARCHIVE_URIS[latest_archive_uri]
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_latest.py
+++ b/tests/test_latest.py
@@ -38,27 +38,6 @@ class TestLastestResources:
         """
         assert latest_paths
 
-    def test_archive_meta_uniqueness(self, latest_paths):
-        """
-        Check that archve_meta is either undefined or unique.
-        """
-        archive_metas = {}
-        for path, schema in latest_paths.items():
-            # It's ok for schemas to not contain this
-            if "archive_meta" not in schema:
-                continue
-
-            archive_meta = schema["archive_meta"].strip()
-
-            # Track the possible duplicates
-            if archive_meta not in archive_metas:
-                archive_metas[archive_meta] = []
-            archive_metas[archive_meta].append(path)
-
-        # Check for duplicates
-        for archive_meta, paths in archive_metas.items():
-            assert len(paths) == 1, f"{paths} contain the same archive_meta: {archive_meta}"
-
     def test_latest_filename(self, latest_path, latest_uri):
         """
         Check that the file name of the schema matches the schema ID WITHOUT the version number suffix.
@@ -195,6 +174,16 @@ class TestLastestResources:
             assert path.parent == latest_datamodels_dir, (
                 f"{latest_tagged_schema_uri} is a datamodel that is not in the top-level directory."
             )
+
+    def test_archive_meta_uniqueness(self, latest_archive_metas, latest_archive_uri, latest_archive_meta):
+        """
+        Check that archve_meta is either undefined or unique.
+        """
+        archive_uris = latest_archive_metas[latest_archive_meta]
+
+        assert len(archive_uris) == 1, (
+            f"Archive meta for {latest_archive_uri} is shared with other URIs: {archive_uris - {latest_archive_uri}}"
+        )
 
     def test_top_level_schema(self, latest_top_level_path, metaschema_uri, latest_paths):
         """


### PR DESCRIPTION
IMOP this is a better uniqueness test:

The failure you fixed in spacetelescope/rad#810 would have looked like

```
FAILED tests/test_latest.py::TestLastestResources::test_archive_meta_uniqueness[asdf://stsci.edu/datamodels/roman/schemas/multiband_segmentation_map-1.1.0] - AssertionError: Archive meta for asdf://stsci.edu/datamodels/roman/schemas/multiband_segmentation_map-1.1.0 is shared with other URIs: {'asdf://stsci.edu/datamodels/roman/schemas/mosaic_segmentation_map-1.6.0'}
FAILED tests/test_latest.py::TestLastestResources::test_archive_meta_uniqueness[asdf://stsci.edu/datamodels/roman/schemas/mosaic_segmentation_map-1.6.0] - AssertionError: Archive meta for asdf://stsci.edu/datamodels/roman/schemas/mosaic_segmentation_map-1.6.0 is shared with other URIs: {'asdf://stsci.edu/datamodels/roman/schemas/multiband_segmentation_map-1.1.0'}
```
